### PR TITLE
Switch to docker compose v2

### DIFF
--- a/examples/jss-headless-proxy-multisite/README.md
+++ b/examples/jss-headless-proxy-multisite/README.md
@@ -9,6 +9,11 @@
 ## Description
 This example shows how to use virtual hosting with the express [vhost](http://expressjs.com/en/resources/middleware/vhost.html) middleware to support multiple JSS sites in the same Headless Proxy instance. It demonstrates sitse can use different application bundles, and sharing a bundle.
 
+### Prerequisites
+* NodeJs 14.x
+* .NET Core 3.1 SDK
+* Docker for Windows, with Windows Containers enabled and Compose V2 support
+
 ## Approach
 * Adds `vhost` to the Headless Proxy.
 * Makes the Headless Proxy configuration dynamic.

--- a/examples/jss-headless-proxy-multisite/docker-compose.override.yml
+++ b/examples/jss-headless-proxy-multisite/docker-compose.override.yml
@@ -10,10 +10,11 @@ services:
       args:
         PARENT_IMAGE: ${NODEJS_PARENT_IMAGE}
         NODEJS_VERSION: ${NODEJS_VERSION}
-    scale: 0
+    deploy:
+      replicas: 0
 
   # The solution build image is added here so it can be referenced as a build dependency
-  # for the images which use its output. Setting "scale: 0" means docker-compose will not
+  # for the images which use its output. Setting "replicas: 0" means docker compose will not
   # include it in the running environment. See Dockerfile for more details.
   solution:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-solution:${VERSION:-latest}
@@ -24,7 +25,8 @@ services:
         BUILD_IMAGE: mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
         NODEJS_IMAGE: ${REGISTRY}${COMPOSE_PROJECT_NAME}-nodejs:${VERSION:-latest}
         REACT_APP_IS_PROXY: "true"
-    scale: 0
+    deploy:
+      replicas: 0
 
   jss:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-jss:${VERSION:-latest}
@@ -132,10 +134,12 @@ services:
       ## Development Environment Optimizations
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,HttpErrorsDetailed,DebugOn,DiagnosticsOff,InitMessagesOff,RobotDetectionOff
       Sitecore_AppSettings_exmEnabled:define: "no" # remove to turn on EXM
-    entrypoint: powershell.exe -Command "& C:\tools\entrypoints\iis\Development.ps1"
+    entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
 
   cd:
-    scale: 0
+    deploy:
+      replicas: 0
 
   redis:
-    scale: 0
+    deploy:
+      replicas: 0

--- a/examples/jss-headless-proxy-multisite/src/platform/App_Config/Include/Sitecore.LoadBalancing.config
+++ b/examples/jss-headless-proxy-multisite/src/platform/App_Config/Include/Sitecore.LoadBalancing.config
@@ -2,7 +2,7 @@
 
 <!--
   Sitecore.LoadBalancing settings are needed when running behind a reverse proxy
-  that handles HTTPS termination, such as the Traefik proxy used in docker-compose
+  that handles HTTPS termination, such as the Traefik proxy used in docker compose
   development environments.
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">

--- a/examples/jss-headless-proxy-multisite/up.ps1
+++ b/examples/jss-headless-proxy-multisite/up.ps1
@@ -9,14 +9,14 @@ if (-not $envCheck) {
 
 # Build all containers in the Sitecore instance, forcing a pull of latest base containers
 Write-Host "Building containers... lots of npm so this may take a moment..." -ForegroundColor Green
-docker-compose build
+docker compose build
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Container build failed, see errors above."
 }
 
 # Start the Sitecore instance
 Write-Host "Starting Sitecore environment..." -ForegroundColor Green
-docker-compose up -d
+docker compose up -d
 
 # Wait for Traefik to expose CM route
 Write-Host "Waiting for CM to become available..." -ForegroundColor Green
@@ -60,5 +60,5 @@ Start-Process https://site-two-b.jssheadlessproxymultisite.localhost/
 
 Write-Host ""
 Write-Host "Use the following command to monitor the Headless Proxy:" -ForegroundColor Green
-Write-Host "docker-compose logs -f jss"
+Write-Host "docker compose logs -f jss"
 Write-Host ""

--- a/examples/nextjs-federated-auth/.env
+++ b/examples/nextjs-federated-auth/.env
@@ -44,7 +44,7 @@ LOCAL_DATA_PATH=.\docker\data\
 HOST_LICENSE_FOLDER=C:\license
 
 # Because we are using a mounted license file, this value can be empty.
-# Included here to suppress 'variable is not set' warning from docker-compose.
+# Included here to suppress 'variable is not set' warning from docker compose.
 SITECORE_LICENSE=
 
 # The isolation mode for Sitecore containers.

--- a/examples/nextjs-federated-auth/README.md
+++ b/examples/nextjs-federated-auth/README.md
@@ -81,12 +81,12 @@ defined in Sitecore's [scope of support](https://kb.sitecore.net/articles/463549
 * .NET Core 3.1 SDK
 * .NET Framework 4.8 SDK
 * Visual Studio 2019
-* Docker for Windows, with Windows Containers enabled
+* Docker for Windows, with Windows Containers enabled and Compose V2 support
 
 See Sitecore Containers documentation for more information on system requirements.
 
 ## What's Included
-* A `docker-compose` environment for a Sitecore XP0 topology
+* A `docker compose` environment for a Sitecore XP0 topology
   with a Next.js rendering host.
 
   > The included `docker-compose.yml` is a stock XP0 environment from the Sitecore

--- a/examples/nextjs-federated-auth/docker-compose.override.yml
+++ b/examples/nextjs-federated-auth/docker-compose.override.yml
@@ -1,5 +1,5 @@
 #
-# The docker-compose.yml in this solution is a stock Sitecore XP0 environment, without
+# The docker compose.yml in this solution is a stock Sitecore XP0 environment, without
 # any changes. This override represents all the additions/changes needed for this solution.
 # Note that some of the overrides point to 'empty' Dockerfiles. This is recommended, even if
 # you are not customizing an image, to enable retagging and later customization. See Sitecore
@@ -18,10 +18,11 @@ services:
       args:
         PARENT_IMAGE: ${NODEJS_PARENT_IMAGE}
         NODEJS_VERSION: ${NODEJS_VERSION}
-    scale: 0
+    deploy:
+      replicas: 0
 
   # The solution build image is added here so it can be referenced as a build dependency
-  # for the images which use its output. Setting "scale: 0" means docker-compose will not
+  # for the images which use its output. Setting "replicas: 0" means docker compose will not
   # include it in the running environment. See Dockerfile for more details.
   solution:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-solution:${VERSION:-latest}
@@ -30,7 +31,8 @@ services:
       args:
         BUILD_CONFIGURATION: ${BUILD_CONFIGURATION}
         BUILD_IMAGE: mcr.microsoft.com/dotnet/framework/sdk:4.8
-    scale: 0
+    deploy:
+      replicas: 0
 
   rendering:
     image: ${REGISTRY}${COMPOSE_PROJECT_NAME}-rendering:${VERSION:-latest}
@@ -131,7 +133,7 @@ services:
       ## Development Environment Optimizations
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,DebugOn,DiagnosticsOff,InitMessagesOff,RobotDetectionOff
       Sitecore_AppSettings_exmEnabled:define: "no" # remove to turn on EXM
-    entrypoint: powershell.exe -Command "& C:\tools\entrypoints\iis\Development.ps1"
+    entrypoint: powershell.exe -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"
 
   # Use our retagged XConnect image.
   # Configure for a mounted license folder instead of using SITECORE_LICENSE.

--- a/examples/nextjs-federated-auth/up.ps1
+++ b/examples/nextjs-federated-auth/up.ps1
@@ -21,14 +21,14 @@ if ($LASTEXITCODE -ne 0) {
 
 # Build all containers in the Sitecore instance, forcing a pull of latest base containers
 Write-Host "Building containers..." -ForegroundColor Green
-docker-compose build
+docker compose build
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Container build failed, see errors above."
 }
 
 # Start the Sitecore instance
 Write-Host "Starting Sitecore environment..." -ForegroundColor Green
-docker-compose up -d
+docker compose up -d
 
 # Wait for Traefik to expose CM route
 Write-Host "Waiting for CM to become available..." -ForegroundColor Green
@@ -109,5 +109,5 @@ Start-Process https://www.nextjsandazureb2c.localhost/
 
 Write-Host ""
 Write-Host "Use the following command to monitor your Rendering Host:" -ForegroundColor Green
-Write-Host "docker-compose logs -f rendering"
+Write-Host "docker compose logs -f rendering"
 Write-Host ""

--- a/examples/sitecore-embedded-jss-app/.env
+++ b/examples/sitecore-embedded-jss-app/.env
@@ -39,7 +39,7 @@ LOCAL_DATA_PATH=.\docker\data\
 HOST_LICENSE_FOLDER=
 
 # Because we are using a mounted license file, this value can be empty.
-# Included here to suppress 'variable is not set' warning from docker-compose.
+# Included here to suppress 'variable is not set' warning from docker compose.
 SITECORE_LICENSE=
 
 # The isolation mode for Sitecore containers.

--- a/examples/sitecore-embedded-jss-app/README.md
+++ b/examples/sitecore-embedded-jss-app/README.md
@@ -39,7 +39,7 @@ You can view a quick [demo video of the sample here](https://content.jwplatform.
 ### Prerequisites
 * NodeJs 14.x
 * .NET Core 3.1 SDK
-* Docker for Windows, with Windows Containers enabled
+* Docker for Windows, with Windows Containers enabled and Compose V2 support
 
 See Sitecore Containers documentation for more information on system requirements.
 
@@ -98,7 +98,7 @@ You can open the Sitecore Content Editor and find the app installed at `/sitecor
 When you're done, stop and remove the containers using the following command.
 
 ```
-docker-compose down
+docker compose down
 ```
 
 ## How it Works

--- a/examples/sitecore-embedded-jss-app/docker-compose.override.yml
+++ b/examples/sitecore-embedded-jss-app/docker-compose.override.yml
@@ -108,4 +108,4 @@ services:
       ## Development Environment Optimizations
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,DebugOn,DiagnosticsOff,InitMessagesOff
       Sitecore_AppSettings_exmEnabled:define: "no" # remove to turn on EXM
-    entrypoint: powershell -Command "& C:\tools\entrypoints\iis\Development.ps1"
+    entrypoint: powershell -Command "& C:\\tools\\entrypoints\\iis\\Development.ps1"

--- a/examples/sitecore-embedded-jss-app/up.ps1
+++ b/examples/sitecore-embedded-jss-app/up.ps1
@@ -9,14 +9,14 @@ if (-not $envCheck) {
 
 # Build all containers in the Sitecore instance, forcing a pull of latest base containers
 Write-Host "Building containers..." -ForegroundColor Green
-docker-compose build
+docker compose build
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Container build failed, see errors above."
 }
 
 # Start the Sitecore instance
 Write-Host "Starting Sitecore environment..." -ForegroundColor Green
-docker-compose up -d
+docker compose up -d
 
 # Wait for Traefik to expose CM route
 Write-Host "Waiting for CM to become available..." -ForegroundColor Green


### PR DESCRIPTION
As Docker Compose V1 reached its EOL (https://www.docker.com/blog/announcing-compose-v2-general-availability/) the repo needs to be updated to use new compose command.